### PR TITLE
Make `force_destroy` a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module to provision an S3 bucket with built in policy to allow [CloudT
 
 This is useful if an organization uses a number of separate AWS accounts to isolate the Audit environment from other environments (production, staging, development).
 
-In this case, you create CloudTrail in the production environment (production AWS account), 
+In this case, you create CloudTrail in the production environment (Production AWS account),
 while the S3 bucket to store the CloudTrail logs is created in the Audit AWS account, restricting access to the logs only to the users/groups from the Audit account.
 
 
@@ -39,6 +39,7 @@ module "s3_bucket" {
 | `tags`            | `{}`                 | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                            | No       |
 | `delimiter`       | `-`                  | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`    | No       |
 | `acl`             | `log-delivery-write` | Canned ACL to apply to the S3 bucket                                          | No       |
+| `force_destroy`   | `false`              | A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable   | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ module "s3_bucket" {
   region                 = "${var.region}"
   acl                    = "${var.acl}"
   policy                 = "${data.aws_iam_policy_document.default.json}"
-  force_destroy          = "false"
+  force_destroy          = "${var.force_destroy}"
   versioning_enabled     = "true"
   lifecycle_rule_enabled = "false"
   delimiter              = "${var.delimiter}"

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "attributes" {
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "acl" {
@@ -41,4 +41,9 @@ variable "region" {
   type        = "string"
   default     = "us-east-1"
   description = "AWS Region for S3 bucket"
+}
+
+variable "force_destroy" {
+  description = "A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable"
+  default     = "false"
 }


### PR DESCRIPTION
## what
* Make `force_destroy` a variable

## why
* For some stages (e.g. `dev` or `test`) we need to be able to destroy the CloudTrail bucket (even if it's not empty) when we destroy the environment with Terraform without manually deleting the objects in the bucket

