### PR TITLE
Add variable to disable default cloud posse tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,4 +80,5 @@ module "s3_bucket" {
   delimiter                          = var.delimiter
   attributes                         = var.attributes
   tags                               = var.tags
+  cloud_posse_tags                   = var.cloud_posse_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
+variable "cloud_posse_tags" {
+  type        = bool
+  default     = true
+  description = "Specifies whether tags should be enhanced with Cloud Posse defaults"
+}
+
 variable "acl" {
   type        = string
   description = "The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"


### PR DESCRIPTION
Thanks for this open source module, I'm planning to use it to setup CloudTrail logs for auditing. I've made a similar PRs on your CloudTrail and S3 Bucket for logging modules as well.

At first I thought that this module wouldn't need to change, but it requires the new variable I'm adding in order to pass it down to the module that creates the S# bucket for the logs.

I'm happy to accommodate any change you recommend, let me know.