### PR TITLE
update s3 bucket dependency for 0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "default" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.14.0"
+  version = "0.17.0"
   enabled = module.this.enabled
 
   acl                                    = var.acl


### PR DESCRIPTION
Hi Andriy ! It's been a while.

## what
* Update S3 log storage dependency for 0.14 readiness.

## why
* Module is not 0.14 ready atm.