### PR TITLE
Chore: bump `s3-log-storage` module to `0.24.1`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_log_label"></a> [access\_log\_label](#module\_access\_log\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#module\_s3\_access\_log\_bucket) | cloudposse/s3-log-storage/aws | 0.23.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 0.23.0 |
+| <a name="module_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#module\_s3\_access\_log\_bucket) | cloudposse/s3-log-storage/aws | 0.24.1 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,8 +19,8 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_log_label"></a> [access\_log\_label](#module\_access\_log\_label) | cloudposse/label/null | 0.25.0 |
-| <a name="module_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#module\_s3\_access\_log\_bucket) | cloudposse/s3-log-storage/aws | 0.23.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 0.23.0 |
+| <a name="module_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#module\_s3\_access\_log\_bucket) | cloudposse/s3-log-storage/aws | 0.24.1 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "access_log_label" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.23.0"
+  version = "0.24.1"
   enabled = module.this.enabled
 
   acl                                    = var.acl
@@ -41,7 +41,7 @@ module "s3_bucket" {
 
 module "s3_access_log_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.23.0"
+  version = "0.24.1"
   enabled = module.this.enabled && var.create_access_log_bucket
 
   acl                                    = var.acl


### PR DESCRIPTION
## what
* Bump `s3-log-storage` module to `0.24.1`.

## why
* The latest version of `s3-log-storage` uses [null-label:0.25.0](https://github.com/cloudposse/terraform-null-label/releases/tag/0.25.0), which allows for a `tenant` label.
* General dependency update.

## references
* https://github.com/cloudposse/terraform-aws-s3-log-storage/releases/tag/0.24.1
* https://github.com/cloudposse/terraform-null-label/releases/tag/0.25.0

