### PR TITLE
add input var s3_object_ownership

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "access_log_label" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "0.28.0"
   enabled = module.this.enabled
 
   acl                                    = var.acl
@@ -38,7 +38,7 @@ module "s3_bucket" {
   bucket_notifications_enabled           = var.bucket_notifications_enabled
   bucket_notifications_type              = var.bucket_notifications_type
   bucket_notifications_prefix            = var.bucket_notifications_prefix
-
+  s3_object_ownership                    = var.s3_object_ownership
   context = module.this.context
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,9 @@ variable "bucket_notifications_prefix" {
   description = "Prefix filter. Used to manage object notifications"
   default     = ""
 }
+
+variable "s3_object_ownership" {
+  type        = string
+  default     = "BucketOwnerPreferred"
+  description = "Specifies the S3 object ownership control. Valid values are `ObjectWriter`, `BucketOwnerPreferred`, and 'BucketOwnerEnforced'."
+}


### PR DESCRIPTION
## what
* Upgrade to version = `"0.28.0"` of the `s3-log-storage` to have the `s3_object_ownership` field available.
* The `s3_object_ownership` field is exposed as an input variable for use by the user consuming the current module.

## why
* When you do not have `acl` , and you have only one account you probably want to restrict so that no other account has use over the `s3 bucket.`

## references
* This resolves [prowler](https://github.com/prowler-cloud/prowler) the next vulnerability when you set `s3_object_ownership = "BucketOwnerEnforced"`
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>

<meta http-equiv="Content-Style-Type" content="text/css">
<meta name="Generator" content="Cocoa HTML Writer">
<meta name="CocoaVersion" content="2113.4">
</head>
<body>


Result | Severity | AccountID | Region | Compliance | Service | CheckID | Check Title | Check Output | CIS Level | CAF Epic | Risk | Remediation | Docs | Resource ID
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
PASS | Medium | xxxxxxx | us-west-2 | Software and Configuration Checks | s3 | 7.172 | [extra7172] Check if S3 buckets have ACLs enabled | us-west-2: Bucket xxxxxx-s3-bucket has bucket ACLs enabled! | Extra | Logging and Monitoring | S3 ACLs are a legacy access control mechanism that predates IAM. IAM and bucket policies are currently the preferred methods. | Ensure that S3 ACLs are disabled (BucketOwnerEnforced). Use IAM policies and bucket policies to manage access. |   | xxxxxx-s3-bucket
* This pr commit resolved: #62 

