### PR TITLE
Update Terraform cloudposse/s3-log-storage/aws to v1.3.1 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "access_log_label" {
 
 module "s3_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "1.3.1"
   enabled = module.this.enabled
 
   acl                                    = var.acl


### PR DESCRIPTION
## what
* Upgrades the dependency module cloudposse/s3-log-storage/aws to its current latest version (1.3.1)

## why
* Make compatible with new S3 defaults by setting S3 Object Ownership before setting ACL and disabling ACL if Ownership is "BucketOwnerEnforced"
* Current give us an error when creating the bucket because of the old standard implemented

## ref
* Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

