### PR TITLE
Fix Race Condition between the Creation of the S3 Bucket Policy and the CloudTrail Trail

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -5,3 +5,13 @@ namespace = "eg"
 stage = "test"
 
 name = "cloudtrail-s3-bucket"
+
+enable_log_file_validation = true
+
+is_multi_region_trail = false
+
+include_global_service_events = false
+
+enable_logging = true
+
+is_organization_trail = false

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -5,13 +5,3 @@ namespace = "eg"
 stage = "test"
 
 name = "cloudtrail-s3-bucket"
-
-enable_log_file_validation = true
-
-is_multi_region_trail = false
-
-include_global_service_events = false
-
-enable_logging = true
-
-is_organization_trail = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,3 +10,17 @@ module "cloudtrail_s3_bucket" {
 
   context = module.this.context
 }
+
+module "cloudtrail" {
+  source  = "cloudposse/cloudtrail/aws"
+  version = "0.23.0"
+
+  enable_logging                = var.enable_logging
+  enable_log_file_validation    = var.enable_log_file_validation
+  include_global_service_events = var.include_global_service_events
+  is_multi_region_trail         = var.is_multi_region_trail
+  is_organization_trail         = var.is_organization_trail
+  s3_bucket_name                = module.cloudtrail_s3_bucket.bucket_id
+
+  context = module.this.context
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,12 +15,8 @@ module "cloudtrail" {
   source  = "cloudposse/cloudtrail/aws"
   version = "0.23.0"
 
-  enable_logging                = var.enable_logging
-  enable_log_file_validation    = var.enable_log_file_validation
-  include_global_service_events = var.include_global_service_events
-  is_multi_region_trail         = var.is_multi_region_trail
-  is_organization_trail         = var.is_organization_trail
-  s3_bucket_name                = module.cloudtrail_s3_bucket.bucket_id
+  is_multi_region_trail = false
+  s3_bucket_name        = module.cloudtrail_s3_bucket.bucket_id
 
   context = module.this.context
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,8 +6,19 @@ output "bucket_domain_name" {
 output "bucket_id" {
   value       = module.s3_bucket.bucket_id
   description = "Bucket ID"
+  #
+  # Ensure the bucket is fully configured before allowing any use of `bucket_id`.
+  #
+  # Although undocumented, `depends_on` is allowed in an output block.
+  # The `bucket_id` is available before the bucket is fully configured 
+  # with policies, versioning, lifecycle, etc. However, all that 
+  # needs to happen before the bucket can be used as a destination for 
+  # a CloudTrail. While the documented way to ensure this would be
+  # for the user of this module to add a `depends_on` that depends
+  # on this module, since this is such a common need, and since
+  # we can depend on a submodule here rather than this entire module,
+  # we add the `depends_on` block here.
   depends_on = [
-    # The S3 bucket policy resource must be created before the bucket is referenced by CloudTrail
     module.s3_bucket
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,10 @@ output "bucket_domain_name" {
 output "bucket_id" {
   value       = module.s3_bucket.bucket_id
   description = "Bucket ID"
+  depends_on = [
+    # The S3 bucket policy resource must be created before the bucket is referenced by CloudTrail
+    module.s3_bucket
+  ]
 }
 
 output "bucket_arn" {


### PR DESCRIPTION
## what

Fix the race condition between the creation of the S3 Bucket policy and the CloudTrail trail by adding a `depends_on` argument to the `bucket_id` output which is used as input to the CloudTrail module. This ensures that all the resources in the CloudTrail S3 Bucket module, including the S3 Bucket Policy have been created before the CloudTrail trail is created.

The example used for the tests has also been updated to include the creation of the CloudTrail Trail to verify that this is working.

## why

- Fixes #90 
