### PR TITLE
feat: add object_lock_configuration support

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -57,6 +57,7 @@ description: |-
   1. Forced [server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) at rest for the S3 bucket
   2. S3 bucket [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) to easily recover from both unintended user actions and application failures
   3. S3 bucket is protected from deletion if it's not empty ([force_destroy](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#force_destroy) set to `false`)
+  4. [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) for WORM (write-once-read-many) protection, useful for compliance requirements (e.g., PCI)
 
 # How to use this project
 usage: |-
@@ -68,6 +69,29 @@ usage: |-
     namespace = "eg"
     stage     = "prod"
     name      = "cluster"
+  }
+  ```
+
+  ### With S3 Object Lock (for compliance)
+
+  S3 Object Lock can only be enabled at bucket creation time and requires versioning (enabled by default).
+
+  ```hcl
+  module "s3_bucket" {
+    source = "cloudposse/cloudtrail-s3-bucket/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+    namespace = "eg"
+    stage     = "prod"
+    name      = "cluster"
+
+    versioning_enabled = true
+
+    object_lock_configuration = {
+      mode  = "GOVERNANCE"
+      days  = 365
+      years = null
+    }
   }
   ```
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "s3_bucket" {
   bucket_notifications_enabled           = var.bucket_notifications_enabled
   bucket_notifications_type              = var.bucket_notifications_type
   bucket_notifications_prefix            = var.bucket_notifications_prefix
+  object_lock_configuration              = var.object_lock_configuration
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,13 @@ variable "bucket_notifications_prefix" {
   description = "Prefix filter. Used to manage object notifications"
   default     = ""
 }
+
+variable "object_lock_configuration" {
+  type = object({
+    mode  = string # Valid values are GOVERNANCE and COMPLIANCE.
+    days  = number
+    years = number
+  })
+  default     = null
+  description = "A configuration for S3 object locking. With S3 Object Lock, you can store objects using a write-once-read-many (WORM) model. Object Lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely."
+}


### PR DESCRIPTION
## what

Add S3 Object Lock pass-through support to the cloudtrail-s3-bucket module for WORM (write-once-read-many) protection. This enables compliance requirements like PCI by preventing CloudTrail logs from being deleted or modified for a specified retention period.

- New `object_lock_configuration` variable on the root module
- Pass-through to underlying `cloudposse/s3-log-storage/aws` module
- Updated documentation with usage example

## why

S3 Object Lock is required for PCI compliance and other regulatory frameworks. The underlying module already supports it, so this is a straightforward pass-through addition that was previously missing from the root module interface.

## references

- AWS documentation: [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html)