### PR TITLE
feat: add object_lock_configuration to s3_access_log_bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ terraform-aws-cloudtrail-s3-bucket.iml
 
 .build-harness
 build-harness
+.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "s3_access_log_bucket" {
   restrict_public_buckets                = var.restrict_public_buckets
   access_log_bucket_name                 = ""
   allow_ssl_requests_only                = var.allow_ssl_requests_only
+  object_lock_configuration              = var.object_lock_configuration
 
   attributes = ["access-logs"]
   context    = module.this.context


### PR DESCRIPTION
## what

- Add `object_lock_configuration` support to the `s3_access_log_bucket` module
- Reuse the existing `object_lock_configuration` variable for both the main bucket and access log bucket
- Add `.terraform.lock.hcl` to `.gitignore`

## why

- The existing `object_lock_configuration` variable was only applied to the main `s3_bucket` module
- Users who enable object locking for compliance/WORM storage should have the same protection on their access log bucket
- Consistent behavior across both buckets reduces configuration surprises

## references

- Extends functionality from #111 which added initial `object_lock_configuration` support