### PR TITLE
fix(access-logs): update S3 bucket configuration with Object Lock

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,11 @@ module "s3_access_log_bucket" {
   restrict_public_buckets                = var.restrict_public_buckets
   access_log_bucket_name                 = ""
   allow_ssl_requests_only                = var.allow_ssl_requests_only
-  object_lock_configuration              = var.object_lock_configuration
+  
+  # S3 buckets with Object Lock can’t be used as destination buckets for server access logs.
+  # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
+  # and https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html
+  object_lock_configuration = null
 
   attributes = ["access-logs"]
   context    = module.this.context

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ module "s3_access_log_bucket" {
   restrict_public_buckets                = var.restrict_public_buckets
   access_log_bucket_name                 = ""
   allow_ssl_requests_only                = var.allow_ssl_requests_only
-  
+
   # S3 buckets with Object Lock can’t be used as destination buckets for server access logs.
   # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
   # and https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html


### PR DESCRIPTION
## what

- Removed the object lock from the access logs bucket

## why

> S3 Object Lock isn't enabled on the destination bucket – Check if the destination bucket has Object Lock enabled. Object Lock blocks server access log delivery. You must choose a destination bucket that doesn't have Object Lock enabled.

## references

- See https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-server-access-logging.html